### PR TITLE
Enhance AI Assistant with content creator roles

### DIFF
--- a/frontend/ai-assistant.html
+++ b/frontend/ai-assistant.html
@@ -13,7 +13,7 @@
     <main>
         <section id="ai-assistant-container">
             <h1>AI Assistant</h1>
-            <p>Your personal guide to Global Peace, Youth Entrepreneurship, and Wellbeing.</p>
+            <p>Your personal guide to Global Peace, Youth Entrepreneurship, Wellbeing, and Creative Content.</p>
             <div id="chat-window">
                 <div id="message-display"></div>
                 <div id="loading-indicator" style="display: none;">Thinking...</div>

--- a/frontend/ai-assistant.js
+++ b/frontend/ai-assistant.js
@@ -63,5 +63,5 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Initial greeting from the assistant
-    displayMessage('assistant', 'Hello! How can I help you today with Global Peace, Youth Entrepreneurship, or Wellbeing?');
+    displayMessage('assistant', 'Hello! How can I help you today with Global Peace, Youth Entrepreneurship, Wellbeing, or content creation like images, videos, and logos?');
 });

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -122,7 +122,7 @@ async function handleAiAssistantRequest(request, env) {
   const MODEL_ID = env.MODEL_ID || 'gemini-1.0-pro-001';
 
   // Specialized prompt for the AI Assistant
-  const prompt = `You are an expert assistant for the "Global Peace, Youth Entrepreneurship, and Wellbeing Platform." Your expertise now includes medicine, education, generative AI, consulting, marketing, software engineering, design, data analytics, business strategy, GPS, maps, video prototype development, video content creation, and prompt concretization. Your goal is to provide helpful and inspiring information on these topics. Please answer the following user query in a clear, concise, and encouraging way:\n\nUser: "${message}"\n\nAssistant:`;
+  const prompt = `You are an expert assistant for the "Global Peace, Youth Entrepreneurship, and Wellbeing Platform." Your expertise now includes medicine, education, generative AI, consulting, marketing, software engineering, design, data analytics, business strategy, GPS, maps, video prototype development, video content creation, prompt concretization, and specialized roles as a pub creator and content creator. You excel at assisting with the creation of images, videos, thumbnails, and logos. Your goal is to provide helpful and inspiring information on these topics. Please answer the following user query in a clear, concise, and encouraging way:\n\nUser: "${message}"\n\nAssistant:`;
 
   const apiUrl = `https://aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/publishers/google/models/${MODEL_ID}:generateContent`;
 


### PR DESCRIPTION
This PR enhances the AI Assistant's persona to include specialized roles as a 'pub creator' and 'content creator'. The agent is now explicitly instructed to assist users with creating images, videos, thumbnails, and logos. Corresponding frontend updates were made to the initial greeting and page description to inform users of these new capabilities.

---
*PR created automatically by Jules for task [1811693613423736801](https://jules.google.com/task/1811693613423736801) started by @GYFX35*

## Summary by Sourcery

Expand the AI assistant’s positioning and system prompt to highlight new creative content support.

New Features:
- Advertise creative content support in the AI assistant UI, including the landing description and initial greeting.
- Extend the assistant’s system prompt to emphasize specialized roles as a pub creator and content creator for images, videos, thumbnails, and logos.